### PR TITLE
Removed webbrowser as dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 PySide2
 PyQt5
 requests
-webbrowser


### PR DESCRIPTION
It's part of the standard library, and throws an error when you install the requirements.